### PR TITLE
CNN url parse error fix

### DIFF
--- a/js/surf.js
+++ b/js/surf.js
@@ -81,10 +81,10 @@ document.getElementById("cnn").onclick = function cnn() {
   var url = $("url").value;
   //this is the URL for the server
   is_url(url);
-  var urlSUB1 = url.replace("-", "_-");
-  var urlSUB = urlSUB1.replace(".", "--");
-  var nerd2 = urlSUB.replace("https://", "");
-  var nerd1 = urlSUB.replace("http://", "");
+  var urlSUB1 = url.replaceAll("-", "_-");
+  var urlSUB = urlSUB1.replaceAll(".", "--");
+  var nerd2 = urlSUB.replaceAll("https://", "");
+  var nerd1 = urlSUB.replaceAll("http://", "");
   var n = url.includes("https://");
   var y = url.includes("http://");
   if (n) {

--- a/js/surf.js
+++ b/js/surf.js
@@ -83,8 +83,8 @@ document.getElementById("cnn").onclick = function cnn() {
   is_url(url);
   var urlSUB1 = url.replaceAll("-", "_-");
   var urlSUB = urlSUB1.replaceAll(".", "--");
-  var nerd2 = urlSUB.replaceAll("https://", "");
-  var nerd1 = urlSUB.replaceAll("http://", "");
+  var nerd2 = urlSUB.replace("https://", "");
+  var nerd1 = urlSUB.replace("http://", "");
   var n = url.includes("https://");
   var y = url.includes("http://");
   if (n) {


### PR DESCRIPTION
when you use a url with multiple '.' or '-' it does not work properly when using the CNN proxy.